### PR TITLE
build(maven): allow maven release plugin to push release changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <spring.version>3.2.1.RELEASE</spring.version>
     <spock.version>0.7-groovy-2.0</spock.version>
     <tomcat-jdbc.version>7.0.37</tomcat-jdbc.version>
-    
+
     <project.build.sourceVersion>1.6</project.build.sourceVersion>
     <project.build.targetVersion>1.6</project.build.targetVersion>
   </properties>
@@ -265,7 +265,6 @@
             <configuration>
                 <autoVersionSubmodules>true</autoVersionSubmodules>
                 <localCheckout>true</localCheckout>
-                <pushChanges>false</pushChanges>
             </configuration>
         </plugin>
    </plugins>
@@ -324,7 +323,7 @@
   </build>
 
   <profiles>
-    <!-- | Used by the continuous integrations server to deploy the project 
+    <!-- | Used by the continuous integrations server to deploy the project
       site. + -->
     <profile>
       <id>ci-local-site</id>
@@ -335,7 +334,7 @@
         </site>
       </distributionManagement>
     </profile>
-    <!-- | Should be activated manually by a developer that wishes to deploy 
+    <!-- | Should be activated manually by a developer that wishes to deploy
       a maven site for | the project + -->
     <profile>
       <id>manual-site</id>


### PR DESCRIPTION
This speeds up the release process by removing the push branch and push tag steps.
While also reducing the change that a release could be cut but accidentally never be tagged and pushed.